### PR TITLE
Save Manager

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -20,6 +20,8 @@
   "MenuBarOptionsStopEmulation": "Stop Emulation",
   "MenuBarOptionsSettings": "_Settings",
   "MenuBarOptionsManageUserProfiles": "_Manage User Profiles",
+  "MenuBarOptionsBackupAllApplications": "Create Application Data Backup",
+  "MenuBarOptionsBackupAllApplicationsTooltip": "Create a backup of all Applications' User, Device, and BCAT Saves, as well as Ryujinx metadata",
   "MenuBarActions": "_Actions",
   "MenuBarOptionsSimulateWakeUpMessage": "Simulate Wake-up message",
   "MenuBarActionsScanAmiibo": "Scan An Amiibo",

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -52,6 +52,8 @@
   "GameListContextMenuOpenBcatSaveDirectoryToolTip": "Opens the directory which contains Application's BCAT Save",
   "GameListContextMenuBackupSaveData": "Backup All Save Data",
   "GameListContextMenuBackupSaveDataToolTip": "Create a backup of the Application's User, Device, and BCAT Saves, as well as Ryujinx metadata",
+  "GameListContextMenuImportSaveData": "Import Save Data Backup",
+  "GameListContextMenuImportSaveDataToolTip": "Import a backup of the Application created by Ryujinx",
   "GameListContextMenuManageTitleUpdates": "Manage Title Updates",
   "GameListContextMenuManageTitleUpdatesToolTip": "Opens the Title Update management window",
   "GameListContextMenuManageDlc": "Manage DLC",

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -46,6 +46,7 @@
   "GameListHeaderFileExtension": "File Ext",
   "GameListHeaderFileSize": "File Size",
   "GameListHeaderPath": "Path",
+  "GameListContextMenuSaveManagement": "Manage Saves",
   "GameListContextMenuOpenUserSaveDirectory": "Open User Save Directory",
   "GameListContextMenuOpenUserSaveDirectoryToolTip": "Opens the directory which contains Application's User Save",
   "GameListContextMenuOpenDeviceSaveDirectory": "Open Device Save Directory",

--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -50,6 +50,8 @@
   "GameListContextMenuOpenDeviceSaveDirectoryToolTip": "Opens the directory which contains Application's Device Save",
   "GameListContextMenuOpenBcatSaveDirectory": "Open BCAT Save Directory",
   "GameListContextMenuOpenBcatSaveDirectoryToolTip": "Opens the directory which contains Application's BCAT Save",
+  "GameListContextMenuBackupSaveData": "Backup All Save Data",
+  "GameListContextMenuBackupSaveDataToolTip": "Create a backup of the Application's User, Device, and BCAT Saves, as well as Ryujinx metadata",
   "GameListContextMenuManageTitleUpdates": "Manage Title Updates",
   "GameListContextMenuManageTitleUpdatesToolTip": "Opens the Title Update management window",
   "GameListContextMenuManageDlc": "Manage DLC",

--- a/src/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/src/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -17,6 +17,7 @@ using Ryujinx.Ava.UI.Controls;
 using Ryujinx.Ava.UI.Helpers;
 using Ryujinx.Ava.UI.Windows;
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Configuration;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.HOS.Services.Account.Acc;
@@ -62,6 +63,12 @@ namespace Ryujinx.Ava.Common
 
         public static async Task<bool> BackupApplicationData(string titleId, string titleName, bool single = true)
         {
+            // TODO: Visualize progress ?
+            return await Task.Run(() => _BackupApplicationData(titleId, titleName, single));
+        }
+
+        private static async Task<bool> _BackupApplicationData(string titleId, string titleName, bool single = true)
+        {
             // TODO: Avoid copying all files to temp directory and then zipping
             //       Rather, open a zip file and chain writes to it, then copy that zip to final dest
 
@@ -93,7 +100,6 @@ namespace Ryujinx.Ava.Common
                 return false;
             }
 
-            
             string backupRoot = Path.Combine(AppDataManager.BaseDirPath, "backup");
             string titleBackupRoot = Path.Combine(backupRoot, titleId);
 
@@ -227,7 +233,7 @@ namespace Ryujinx.Ava.Common
                 if (File.Exists(zipPath)) {
                     File.Delete(zipPath);
                 }
-                ZipFile.CreateFromDirectory(backupPath, zipPath);
+                ZipFile.CreateFromDirectory(backupPath, zipPath, compressionLevel: CompressionLevel.SmallestSize, includeBaseDirectory: titleId != "");
             }
 
             // return true if the output file was successfully created

--- a/src/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/src/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -141,9 +141,9 @@ namespace Ryujinx.Ava.Common
         }
 
         private static string BackupRyujinxData(string titleId, string titleBackupRoot) {
-            string dataPath = Path.Combine(AppDataManager.GamesDirPath, titleId);
-            string outputPath = Path.Combine(titleBackupRoot, "Ryu");
-            return CopyDirectory(dataPath, outputPath) ? outputPath : "";
+            string metadataPath = Path.Combine(AppDataManager.GamesDirPath, titleId, "gui"); // only save gui info bc update/dlc/caches are system dependent
+            string outputPath = Path.Combine(titleBackupRoot, "Ryu", "gui");
+            return CopyDirectory(metadataPath, outputPath) ? outputPath : "";
         }
 
         // fetch the user save data for userId and titleId and backs it up to /backup dir 

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -23,6 +23,11 @@
         Header="{locale:Locale GameListContextMenuOpenBcatSaveDirectory}"
         IsEnabled="{Binding OpenBcatSaveDirectoryEnabled}"
         ToolTip.Tip="{locale:Locale GameListContextMenuOpenBcatSaveDirectoryToolTip}" />
+    <MenuItem
+        Click="BackupSaveData_Click"
+        Header="{locale:Locale GameListContextMenuBackupSaveData}"
+        IsEnabled="{Binding BackupSaveDataEnabled}"
+        ToolTip.Tip="{locale:Locale GameListContextMenuBackupSaveDataToolTip}" />
     <Separator />
     <MenuItem
         Click="OpenTitleUpdateManager_Click"

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -28,6 +28,10 @@
         Header="{locale:Locale GameListContextMenuBackupSaveData}"
         IsEnabled="{Binding BackupSaveDataEnabled}"
         ToolTip.Tip="{locale:Locale GameListContextMenuBackupSaveDataToolTip}" />
+    <MenuItem
+        Click="ImportSaveData_Click"
+        Header="{locale:Locale GameListContextMenuImportSaveData}"
+        ToolTip.Tip="{locale:Locale GameListContextMenuImportSaveDataToolTip}" />
     <Separator />
     <MenuItem
         Click="OpenTitleUpdateManager_Click"

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -8,31 +8,33 @@
         Header="{locale:Locale GameListContextMenuToggleFavorite}"
         ToolTip.Tip="{locale:Locale GameListContextMenuToggleFavoriteToolTip}" />
     <Separator />
-    <MenuItem
-        Click="OpenUserSaveDirectory_Click"
-        Header="{locale:Locale GameListContextMenuOpenUserSaveDirectory}"
-        IsEnabled="{Binding OpenUserSaveDirectoryEnabled}"
-        ToolTip.Tip="{locale:Locale GameListContextMenuOpenUserSaveDirectoryToolTip}" />
-    <MenuItem
-        Click="OpenDeviceSaveDirectory_Click"
-        Header="{locale:Locale GameListContextMenuOpenDeviceSaveDirectory}"
-        IsEnabled="{Binding OpenDeviceSaveDirectoryEnabled}"
-        ToolTip.Tip="{locale:Locale GameListContextMenuOpenDeviceSaveDirectoryToolTip}" />
-    <MenuItem
-        Click="OpenBcatSaveDirectory_Click"
-        Header="{locale:Locale GameListContextMenuOpenBcatSaveDirectory}"
-        IsEnabled="{Binding OpenBcatSaveDirectoryEnabled}"
-        ToolTip.Tip="{locale:Locale GameListContextMenuOpenBcatSaveDirectoryToolTip}" />
-    <MenuItem
-        Click="BackupSaveData_Click"
-        Header="{locale:Locale GameListContextMenuBackupSaveData}"
-        IsEnabled="{Binding BackupSaveDataEnabled}"
-        ToolTip.Tip="{locale:Locale GameListContextMenuBackupSaveDataToolTip}" />
-    <MenuItem
-        Click="ImportSaveData_Click"
-        Header="{locale:Locale GameListContextMenuImportSaveData}"
-        ToolTip.Tip="{locale:Locale GameListContextMenuImportSaveDataToolTip}" />
-    <Separator />
+    <MenuItem Header="{locale:Locale GameListContextMenuSaveManagement}">
+        <MenuItem
+            Click="OpenUserSaveDirectory_Click"
+            Header="{locale:Locale GameListContextMenuOpenUserSaveDirectory}"
+            IsEnabled="{Binding OpenUserSaveDirectoryEnabled}"
+            ToolTip.Tip="{locale:Locale GameListContextMenuOpenUserSaveDirectoryToolTip}" />
+        <MenuItem
+            Click="OpenDeviceSaveDirectory_Click"
+            Header="{locale:Locale GameListContextMenuOpenDeviceSaveDirectory}"
+            IsEnabled="{Binding OpenDeviceSaveDirectoryEnabled}"
+            ToolTip.Tip="{locale:Locale GameListContextMenuOpenDeviceSaveDirectoryToolTip}" />
+        <MenuItem
+            Click="OpenBcatSaveDirectory_Click"
+            Header="{locale:Locale GameListContextMenuOpenBcatSaveDirectory}"
+            IsEnabled="{Binding OpenBcatSaveDirectoryEnabled}"
+            ToolTip.Tip="{locale:Locale GameListContextMenuOpenBcatSaveDirectoryToolTip}" />
+        <Separator />
+        <MenuItem
+            Click="BackupSaveData_Click"
+            Header="{locale:Locale GameListContextMenuBackupSaveData}"
+            IsEnabled="{Binding BackupSaveDataEnabled}"
+            ToolTip.Tip="{locale:Locale GameListContextMenuBackupSaveDataToolTip}" />
+        <MenuItem
+            Click="ImportSaveData_Click"
+            Header="{locale:Locale GameListContextMenuImportSaveData}"
+            ToolTip.Tip="{locale:Locale GameListContextMenuImportSaveDataToolTip}" />
+    </MenuItem>
     <MenuItem
         Click="OpenTitleUpdateManager_Click"
         Header="{locale:Locale GameListContextMenuManageTitleUpdates}"

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -93,6 +93,35 @@ namespace Ryujinx.Ava.UI.Controls
             }
         }
 
+        public async void BackupSaveData_Click(object sender, RoutedEventArgs args)
+        {
+            if ((sender as MenuItem)?.DataContext is MainWindowViewModel viewModel)
+            {
+                if (viewModel?.SelectedApplication != null)
+                {    
+                    bool didBackupSucceed = await ApplicationHelper.BackupSaveDir(viewModel.AccountManager.GetAllUsers(), viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName);
+                    
+                    // TODO: Localize
+                    await Dispatcher.UIThread.InvokeAsync(async () => {
+                        if (didBackupSucceed) {
+                                await ContentDialogHelper.CreateInfoDialog(
+                                    "Backup success",
+                                    $"Successfully backed up save data folder for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]",
+                                    LocaleManager.Instance[LocaleKeys.InputDialogOk],
+                                    "",
+                                    LocaleManager.Instance[LocaleKeys.RyujinxInfo]
+                                );
+                        } else {
+                            await ContentDialogHelper.CreateWarningDialog(
+                                "Backup Error", 
+                                $"Error backing up data for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]"
+                            );
+                        }
+                    });
+                }
+            }
+        }
+
         public async void OpenTitleUpdateManager_Click(object sender, RoutedEventArgs args)
         {
             var viewModel = (sender as MenuItem)?.DataContext as MainWindowViewModel;

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.Ava.UI.Controls
             {
                 if (viewModel?.SelectedApplication != null)
                 {    
-                    bool didBackupSucceed = await ApplicationHelper.BackupSaveDir(viewModel.AccountManager.GetAllUsers(), viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName);
+                    bool didBackupSucceed = await ApplicationHelper.BackupApplicationData(viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName);
                     
                     // TODO: Localize
                     await Dispatcher.UIThread.InvokeAsync(async () => {
@@ -115,6 +115,35 @@ namespace Ryujinx.Ava.UI.Controls
                             await ContentDialogHelper.CreateWarningDialog(
                                 "Backup Error", 
                                 $"Error backing up data for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]"
+                            );
+                        }
+                    });
+                }
+            }
+        }
+
+        public async void ImportSaveData_Click(object sender, RoutedEventArgs args)
+        {
+            if ((sender as MenuItem)?.DataContext is MainWindowViewModel viewModel)
+            {
+                if (viewModel?.SelectedApplication != null)
+                {    
+                    bool didImportSucceed = await ApplicationHelper.ImportDataBackup(viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName);
+                    
+                    // TODO: Localize
+                    await Dispatcher.UIThread.InvokeAsync(async () => {
+                        if (didImportSucceed) {
+                                await ContentDialogHelper.CreateInfoDialog(
+                                    "Import success",
+                                    $"Successfully imported backup for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]",
+                                    LocaleManager.Instance[LocaleKeys.InputDialogOk],
+                                    "",
+                                    LocaleManager.Instance[LocaleKeys.RyujinxInfo]
+                                );
+                        } else {
+                            await ContentDialogHelper.CreateWarningDialog(
+                                "Import Error", 
+                                $"Error importing the backup for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]"
                             );
                         }
                     });

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -128,11 +128,11 @@ namespace Ryujinx.Ava.UI.Controls
             {
                 if (viewModel?.SelectedApplication != null)
                 {    
-                    bool didImportSucceed = await ApplicationHelper.ImportDataBackup(viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName);
+                    (bool didSucceed, string error) result = await ApplicationHelper.ImportDataBackup(viewModel.SelectedApplication.TitleId, viewModel.SelectedApplication.TitleName, viewModel.SelectedApplication.ControlHolder);
                     
                     // TODO: Localize
                     await Dispatcher.UIThread.InvokeAsync(async () => {
-                        if (didImportSucceed) {
+                        if (result.didSucceed) {
                                 await ContentDialogHelper.CreateInfoDialog(
                                     "Import success",
                                     $"Successfully imported backup for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]",
@@ -142,8 +142,8 @@ namespace Ryujinx.Ava.UI.Controls
                                 );
                         } else {
                             await ContentDialogHelper.CreateWarningDialog(
-                                "Import Error", 
-                                $"Error importing the backup for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]"
+                                $"Error importing the backup for {viewModel.SelectedApplication.TitleName} [{viewModel.SelectedApplication.TitleId}]", 
+                                $"{result.error}"
                             );
                         }
                     });

--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -12,6 +12,7 @@ using Ryujinx.Common.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Ryujinx.Ava.UI.Helpers
 {
@@ -386,6 +387,30 @@ namespace Ryujinx.Ava.UI.Helpers
             }
 
             return result;
+        }
+
+        public static async Task<string> ShowSaveFileDialog(
+            string title = "", 
+            string initialFilename = "", 
+            List<FileDialogFilter> filters = null, 
+            string defaultExtension = ""
+        )
+        {
+            SaveFileDialog saveFileDialog = new SaveFileDialog();
+            if (title != "") {
+                saveFileDialog.Title = title;
+            }
+            if (initialFilename != "") {
+                saveFileDialog.InitialFileName = initialFilename;
+            }
+            if (filters != null) {
+                saveFileDialog.Filters = filters;
+            }
+            if (defaultExtension != "") {
+                saveFileDialog.DefaultExtension = defaultExtension;
+            }
+
+            return await saveFileDialog.ShowAsync(GetMainWindow());
         }
 
         private static Window GetMainWindow()

--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -389,6 +389,15 @@ namespace Ryujinx.Ava.UI.Helpers
             return result;
         }
 
+        public static FileDialogFilter GetRyubakFileFilter()
+        {
+            FileDialogFilter ryubakFilter = new FileDialogFilter();
+            ryubakFilter.Extensions = new List<string> { "ryubak" };
+            ryubakFilter.Name = "Ryujinx Backup File";
+
+            return ryubakFilter;
+        }
+
         public static async Task<string> ShowSaveFileDialog(
             string title = "", 
             string initialFilename = "", 
@@ -411,6 +420,25 @@ namespace Ryujinx.Ava.UI.Helpers
             }
 
             return await saveFileDialog.ShowAsync(GetMainWindow());
+        }
+
+        public static async Task<string[]> ShowOpenFileDialog(
+            string title = "", 
+            List<FileDialogFilter> filters = null,
+            bool allowsMultiple = false
+        )
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            if (title != "") {
+                openFileDialog.Title = title;
+            }
+            if (filters != null) {
+                openFileDialog.Filters = filters;
+            }
+
+            openFileDialog.AllowMultiple = allowsMultiple;
+
+            return await openFileDialog.ShowAsync(GetMainWindow());
         }
 
         private static Window GetMainWindow()

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -347,6 +347,8 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool OpenDeviceSaveDirectoryEnabled => !Utilities.IsZeros(SelectedApplication.ControlHolder.ByteSpan) && SelectedApplication.ControlHolder.Value.DeviceSaveDataSize > 0;
 
         public bool OpenBcatSaveDirectoryEnabled => !Utilities.IsZeros(SelectedApplication.ControlHolder.ByteSpan) && SelectedApplication.ControlHolder.Value.BcatDeliveryCacheStorageSize > 0;
+        
+        public bool BackupSaveDataEnabled => OpenUserSaveDirectoryEnabled || OpenDeviceSaveDirectoryEnabled || OpenBcatSaveDirectoryEnabled;
 
         public string LoadHeading
         {

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -347,7 +347,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool OpenDeviceSaveDirectoryEnabled => !Utilities.IsZeros(SelectedApplication.ControlHolder.ByteSpan) && SelectedApplication.ControlHolder.Value.DeviceSaveDataSize > 0;
 
         public bool OpenBcatSaveDirectoryEnabled => !Utilities.IsZeros(SelectedApplication.ControlHolder.ByteSpan) && SelectedApplication.ControlHolder.Value.BcatDeliveryCacheStorageSize > 0;
-        
+
         public bool BackupSaveDataEnabled => OpenUserSaveDirectoryEnabled || OpenDeviceSaveDirectoryEnabled || OpenBcatSaveDirectoryEnabled;
 
         public string LoadHeading
@@ -1359,6 +1359,26 @@ namespace Ryujinx.Ava.UI.ViewModels
         public async void ManageProfiles()
         {
             await NavigationDialogHost.Show(AccountManager, ContentManager, VirtualFileSystem, LibHacHorizonManager.RyujinxClient);
+        }
+
+        public async void BackupAllApplicationsData()
+        {
+            bool didSucceed = await ApplicationHelper.BackupAllApplicationData(new List<ApplicationData>(Applications));
+            
+            if (didSucceed) {
+                await ContentDialogHelper.CreateInfoDialog(
+                    "Backup success",
+                    $"Successfully backed up all save data !",
+                    LocaleManager.Instance[LocaleKeys.InputDialogOk],
+                    "",
+                    LocaleManager.Instance[LocaleKeys.RyujinxInfo]
+                );
+            } else {
+                await ContentDialogHelper.CreateWarningDialog(
+                    "Backup Error", 
+                    "Some save data could not be backed up" // TODO: Be more specific !
+                );
+            }
         }
 
         public void SimulateWakeUpMessage()

--- a/src/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
@@ -89,6 +89,11 @@
                     Header="{locale:Locale MenuBarOptionsManageUserProfiles}"
                     IsEnabled="{Binding EnableNonGameRunningControls}"
                     ToolTip.Tip="{locale:Locale OpenProfileManagerTooltip}" />
+                <MenuItem
+                    Command="{ReflectionBinding BackupAllApplicationsData}"
+                    Header="{locale:Locale MenuBarOptionsBackupAllApplications}"
+                    IsEnabled="{Binding EnableNonGameRunningControls}"
+                    ToolTip.Tip="{locale:Locale MenuBarOptionsBackupAllApplicationsTooltip}" />
             </MenuItem>
             <MenuItem
                 Name="ActionsMenuItem"


### PR DESCRIPTION
A (very) early implementation of a more thorough save manager logic for Ryujinx. 

Features:
- Backup all data for a single application
  - User saves
  - Device saves
  - BCAT saves
  - Ryujinx metadata (time played, last played, etc)
- Import all data for a single application
  - See data exported above
- Backup all data for all applications with data
  - Same data as is exported for single app
  
  
![image](https://github.com/tarrouye/Ryujinx/assets/5017270/c4f71f7a-ad76-4250-b54c-2c5d80f09773)

![image](https://github.com/tarrouye/Ryujinx/assets/5017270/28d216e8-aeee-49b5-8e8d-e974f036d35d)

Want to add:
- Import data for all applications installed in Ryujinx
  - Skip applications that aren't installed but warn the user so they can import again after adding the application
- Allow user to exclude applications from full backup
- Allow user to exclude applications from full import
- Handle user profile mapping
  - Save Ryujinx user profile metadata to backup
  - Read user profile metadata from backup and map it to current Ryujinx profiles
    - Create / map profiles as appropriate
- Also support simple folder input (ez imort from JKSV/Yuzu/Simple backup from directory/etc)
  - Allow user to choose an Application then select whether the save should be imported under Device, BCAT, or a User Profile
- A lot of clean-up
- Consolidate with existing logic under user profile manager
- Better Import / export UI
  - Parse available data and allow enable/disable each user/device/bcat/ryujinx entry for each application
 

Maybe to add:
- Create a backup for application before launching it and offer to restore that backup if corruption occurs
- CLI